### PR TITLE
Kubo Compat + Dag Endpoints

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ language: haskell
 before_install:
 - mkdir -p $HOME/.local/bin; export PATH=$HOME/.local/bin:$PATH;
 - travis_retry curl -L https://www.stackage.org/stack/linux-x86_64 | tar xz --wildcards --strip-components=1 -C ~/.local/bin '*/stack';
-- travis_retry curl -L https://dist.ipfs.io/go-ipfs/v0.4.15/go-ipfs_v0.4.15_linux-amd64.tar.gz | tar xz --wildcards --strip-components=1 -C ~/.local/bin '*/ipfs'
+- travis_retry curl -L https://dist.ipfs.io/go-ipfs/v0.19.1/go-ipfs_v0.19.1_linux-amd64.tar.gz | tar xz --wildcards --strip-components=1 -C ~/.local/bin '*/ipfs'
 - ipfs init
 - ipfs daemon &
 - stack setup

--- a/ipfs-api.cabal
+++ b/ipfs-api.cabal
@@ -1,8 +1,10 @@
--- This file has been generated from package.yaml by hpack version 0.28.2.
+cabal-version: 1.12
+
+-- This file has been generated from package.yaml by hpack version 0.35.1.
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 2d53debac40d2564a412e9ef44dc4af490d2ecd7d50e7ec424d5b9124687177d
+-- hash: d34d5119cb814530d0c26cc23e7b28f795d2989534ffceb6fbcea8e7a650b3b7
 
 name:           ipfs-api
 version:        0.1.0.0
@@ -16,10 +18,9 @@ copyright:      2018 Ilya Ostrovskiy
 license:        BSD3
 license-file:   LICENSE
 build-type:     Simple
-cabal-version:  >= 1.10
 extra-source-files:
-    ChangeLog.md
     README.md
+    ChangeLog.md
 
 source-repository head
   type: git
@@ -28,25 +29,40 @@ source-repository head
 library
   hs-source-dirs:
       src
-  default-extensions: DataKinds FlexibleContexts FlexibleInstances GeneralizedNewtypeDeriving LambdaCase MultiParamTypeClasses OverloadedStrings PolyKinds ScopedTypeVariables TypeApplications TypeFamilies TypeOperators
+  default-extensions:
+      DataKinds
+      FlexibleContexts
+      FlexibleInstances
+      GeneralizedNewtypeDeriving
+      LambdaCase
+      MultiParamTypeClasses
+      OverloadedStrings
+      PolyKinds
+      ScopedTypeVariables
+      TypeApplications
+      TypeFamilies
+      TypeOperators
   build-depends:
-      aeson >=1.2 && <1.3
-    , attoparsec >=0.13 && <0.14
-    , base >=4.7 && <5
-    , binary >=0.8.5.0 && <0.9
-    , bytestring >=0.10.0.0 && <0.11
-    , containers >=0.5.10 && <0.6
-    , http-client >=0.5.12 && <0.6
-    , http-media >=0.7 && <0.8
-    , http-types >=0.12 && <0.13
-    , servant >=0.13 && <0.14
-    , servant-client >=0.13 && <0.14
-    , servant-client-core >=0.13 && <0.14
-    , text >=1.2.3.0 && <1.3
-    , unordered-containers >=0.2.9 && <0.3
+      aeson
+    , attoparsec
+    , base
+    , binary
+    , bytestring
+    , containers
+    , http-client
+    , http-media
+    , http-types
+    , ipld-cid
+    , servant
+    , servant-client
+    , servant-client-core
+    , string-conversions
+    , text
+    , unordered-containers
   exposed-modules:
       Network.IPFS.API.V0
       Network.IPFS.API.V0.Block
+      Network.IPFS.API.V0.Dag
       Network.IPFS.API.V0.Pin
       Network.IPFS.API.V0.Quirks
       Network.IPFS.API.V0.Types
@@ -61,24 +77,38 @@ executable ipfs-api-exe
   main-is: Main.hs
   hs-source-dirs:
       app
-  default-extensions: DataKinds FlexibleContexts FlexibleInstances GeneralizedNewtypeDeriving LambdaCase MultiParamTypeClasses OverloadedStrings PolyKinds ScopedTypeVariables TypeApplications TypeFamilies TypeOperators
+  default-extensions:
+      DataKinds
+      FlexibleContexts
+      FlexibleInstances
+      GeneralizedNewtypeDeriving
+      LambdaCase
+      MultiParamTypeClasses
+      OverloadedStrings
+      PolyKinds
+      ScopedTypeVariables
+      TypeApplications
+      TypeFamilies
+      TypeOperators
   ghc-options: -threaded -rtsopts -with-rtsopts=-N
   build-depends:
-      aeson >=1.2 && <1.3
-    , attoparsec >=0.13 && <0.14
-    , base >=4.7 && <5
-    , binary >=0.8.5.0 && <0.9
-    , bytestring >=0.10.0.0 && <0.11
-    , containers >=0.5.10 && <0.6
-    , http-client >=0.5.12 && <0.6
-    , http-media >=0.7 && <0.8
-    , http-types >=0.12 && <0.13
+      aeson
+    , attoparsec
+    , base
+    , binary
+    , bytestring
+    , containers
+    , http-client
+    , http-media
+    , http-types
     , ipfs-api
-    , servant >=0.13 && <0.14
-    , servant-client >=0.13 && <0.14
-    , servant-client-core >=0.13 && <0.14
-    , text >=1.2.3.0 && <1.3
-    , unordered-containers >=0.2.9 && <0.3
+    , ipld-cid
+    , servant
+    , servant-client
+    , servant-client-core
+    , string-conversions
+    , text
+    , unordered-containers
   other-modules:
       Paths_ipfs_api
   default-language: Haskell2010
@@ -88,32 +118,47 @@ test-suite ipfs-api-test
   main-is: Spec.hs
   hs-source-dirs:
       test
-  default-extensions: DataKinds FlexibleContexts FlexibleInstances GeneralizedNewtypeDeriving LambdaCase MultiParamTypeClasses OverloadedStrings PolyKinds ScopedTypeVariables TypeApplications TypeFamilies TypeOperators
+  default-extensions:
+      DataKinds
+      FlexibleContexts
+      FlexibleInstances
+      GeneralizedNewtypeDeriving
+      LambdaCase
+      MultiParamTypeClasses
+      OverloadedStrings
+      PolyKinds
+      ScopedTypeVariables
+      TypeApplications
+      TypeFamilies
+      TypeOperators
   ghc-options: -threaded -rtsopts -with-rtsopts=-N
   build-depends:
-      aeson >=1.2 && <1.3
-    , attoparsec >=0.13 && <0.14
-    , base >=4.7 && <5
-    , binary >=0.8.5.0 && <0.9
-    , bytestring >=0.10.0.0 && <0.11
-    , containers >=0.5.10 && <0.6
+      aeson
+    , attoparsec
+    , base
+    , binary
+    , bytestring
+    , containers
     , hspec
     , hspec-contrib
     , hspec-discover
     , hspec-expectations
-    , http-client >=0.5.12 && <0.6
-    , http-media >=0.7 && <0.8
-    , http-types >=0.12 && <0.13
+    , http-client
+    , http-media
+    , http-types
     , ipfs-api
-    , servant >=0.13 && <0.14
-    , servant-client >=0.13 && <0.14
-    , servant-client-core >=0.13 && <0.14
-    , text >=1.2.3.0 && <1.3
-    , unordered-containers >=0.2.9 && <0.3
+    , ipld-cid
+    , servant
+    , servant-client
+    , servant-client-core
+    , string-conversions
+    , text
+    , unordered-containers
   other-modules:
       Utils
       V0.BaseAPISpec
       V0.BlockAPISpec
+      V0.DagAPISpec
       V0.PinAPISpec
       Paths_ipfs_api
   default-language: Haskell2010

--- a/ipfs-api.cabal
+++ b/ipfs-api.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: d34d5119cb814530d0c26cc23e7b28f795d2989534ffceb6fbcea8e7a650b3b7
+-- hash: 9eb0a71818160fa05d9a767cf89680c42d2f54e5f096fe3f5d0e1120b44a3c1c
 
 name:           ipfs-api
 version:        0.1.0.0
@@ -42,6 +42,7 @@ library
       TypeApplications
       TypeFamilies
       TypeOperators
+  ghc-options: -Werror
   build-depends:
       aeson
     , attoparsec

--- a/package.yaml
+++ b/package.yaml
@@ -20,20 +20,22 @@ category:            Web
 description:         Please see the README on GitHub at <https://github.com/f-o-a-m/ipfs-api#readme>
 
 dependencies:
-- base >= 4.7 && < 5
-- aeson >= 1.2 && < 1.3
-- attoparsec >= 0.13 && < 0.14
-- binary >= 0.8.5.0 && < 0.9
-- bytestring >= 0.10.0.0 && < 0.11
-- containers >= 0.5.10 && < 0.6
-- http-client >= 0.5.12 && < 0.6
-- http-media >= 0.7 && < 0.8
-- http-types >= 0.12 && < 0.13
-- servant >= 0.13 && < 0.14
-- servant-client >= 0.13 && < 0.14
-- servant-client-core >= 0.13 && < 0.14
-- text >= 1.2.3.0 && < 1.3
-- unordered-containers >= 0.2.9 && < 0.3
+- base
+- aeson
+- attoparsec 
+- binary
+- bytestring
+- containers
+- http-client
+- http-media
+- http-types
+- ipld-cid
+- servant 
+- servant-client
+- servant-client-core
+- string-conversions
+- text
+- unordered-containers
 
 default-extensions:
 - DataKinds

--- a/package.yaml
+++ b/package.yaml
@@ -52,6 +52,8 @@ default-extensions:
 - TypeOperators
 
 library:
+  ghc-options:
+  - -Werror
   source-dirs: src
 
 executables:

--- a/src/Network/IPFS/API/V0.hs
+++ b/src/Network/IPFS/API/V0.hs
@@ -10,6 +10,7 @@ module Network.IPFS.API.V0
 
 import           Data.Proxy
 import           Network.IPFS.API.V0.Block  as Block
+import           Network.IPFS.API.V0.Dag    as Dag
 import           Network.IPFS.API.V0.Pin    as Pin
 import           Network.IPFS.API.V0.Quirks as Quirks
 import           Network.IPFS.API.V0.Types  as Types
@@ -20,6 +21,7 @@ type ApiV0 = "api" :> "v0" :>
   (    V0.RootApi
   :<|> Block.BlockApi
   :<|> Pin.PinApi
+  :<|> Dag.DagApi
   )
 
 apiV0 :: Proxy ApiV0

--- a/src/Network/IPFS/API/V0/Block.hs
+++ b/src/Network/IPFS/API/V0/Block.hs
@@ -16,7 +16,7 @@ type BlockGet =
 
 type BlockPut =
   "block" :> "put"
-          :> MultipartFormDataReqBody BlockPutData
+          :> MultipartFormDataReqBody PutData
           :> Post '[JSON] BlockStatResponse
 
 type BlockStat =

--- a/src/Network/IPFS/API/V0/Block.hs
+++ b/src/Network/IPFS/API/V0/Block.hs
@@ -12,7 +12,7 @@ type BlockApi = (BlockGet :<|> BlockPut :<|> BlockStat :<|> BlockRm)
 type BlockGet =
   "block" :> "get"
           :> IPFSArg "block-multihash" Multihash
-          :> Get '[PlainTextBinary] ByteString
+          :> Post '[PlainTextBinary] ByteString
 
 type BlockPut =
   "block" :> "put"
@@ -22,9 +22,9 @@ type BlockPut =
 type BlockStat =
   "block" :> "stat"
           :> IPFSArg "block-multihash" Multihash
-          :> Get '[JSON] BlockStatResponse
+          :> Post '[JSON] BlockStatResponse
 
 type BlockRm =
   "block" :> "rm"
           :> IPFSArg "block-multihash" Multihash
-          :> Get '[JSON] BlockRmResponse
+          :> Post '[JSON] BlockRmResponse

--- a/src/Network/IPFS/API/V0/Dag.hs
+++ b/src/Network/IPFS/API/V0/Dag.hs
@@ -1,0 +1,21 @@
+module Network.IPFS.API.V0.Dag where
+
+import           Data.ByteString.Lazy       (ByteString)
+import           Servant.API
+import           Servant.MultipartFormData
+import           Network.IPFS.API.V0.Types
+import           Network.IPFS.API.V0.Quirks
+
+type DagApi = (GetDag :<|> PutDag)
+
+type GetDag =
+  "dag" :> "get"
+        :> IPFSArg "dag-multihash" Multihash
+        :> QueryParam "output-codec" DagDataEncoding
+        :> Post '[PlainTextBinary] ByteString
+
+type PutDag =
+  "dag" :> "put"
+        :> QueryParam "input-codec" DagDataEncoding
+        :> MultipartFormDataReqBody [AddFile]
+        :> Post '[JSON] CIDResponse

--- a/src/Network/IPFS/API/V0/Pin.hs
+++ b/src/Network/IPFS/API/V0/Pin.hs
@@ -14,27 +14,27 @@ type PinAdd =
         :> IPFSArg "path" String
         :> QueryFlag "recursive"
         :> QueryFlag "progress"
-        :> Get '[JSON] PinModResponse
+        :> Post '[JSON] PinModResponse
 
 type PinLs =
   "pin" :> "ls"
         :> IPFSArgOpt "path" String
         :> QueryParam "type" PinListType
-        :> Get '[JSON] PinLsResponse
+        :> Post '[JSON] PinLsResponse
 
 type PinRm =
   "pin" :> "rm"
         :> IPFSArg "unpin" String
         :> QueryFlag "recursive"
-        :> Get '[JSON] PinModResponse
+        :> Post '[JSON] PinModResponse
 
 type PinUpdate =
   "pin" :> "update"
         :> IPFSArg "old" String
         :> IPFSArg "new" String
         :> QueryFlag "unpin"
-        :> Get '[JSON] String -- PinUpdateResponse
+        :> Post '[JSON] String -- PinUpdateResponse
 
 type PinVerify =
   "pin" :> "verify"
-        :> Get '[RespondsWithNothing] () -- it response with nothing??
+        :> Post '[RespondsWithNothing] () -- it response with nothing??

--- a/src/Network/IPFS/API/V0/Types.hs
+++ b/src/Network/IPFS/API/V0/Types.hs
@@ -77,12 +77,15 @@ instance FromJSON AddObjectResponse where
                       <*> (o .: "Size" <|> (read <$> o .: "Size")) -- Size is Strung sometimes ಠ_______________ಠ
 
 --------------------------------------------------------------
--- multipart form data for /api/v0/block/put
-newtype BlockPutData = BlockPutData ByteString
+-- multipart form data for 
+-- /api/v0/block/put
+-- /api/v0/dag/put
+
+newtype PutData = PutData ByteString
   deriving (Eq, Ord, Read, Show)
 
-instance ToMultipartFormData BlockPutData where
-  toMultipartFormData (BlockPutData d) = [partFileRequestBody "arg" "arg" (RequestBodyLBS d)]
+instance ToMultipartFormData PutData where
+  toMultipartFormData (PutData d) = [partFileRequestBody "arg" "arg" (RequestBodyLBS d)]
 
 --------------------------------------------------------------
 -- response for /api/v0/block/put and .../block/stat
@@ -171,3 +174,28 @@ instance FromJSON PinLsResponse where
     where parseKeys (k, v) = flip (withObject "PinListType") v $ \t -> do
             t' <- parseJSON =<< t .: "Type"
             return (Text.unpack k, t')
+
+--------------------------------------------------------------
+
+data DagDataEncoding
+  = DagJSON
+  | DagPB
+  | DagCBOR
+  deriving (Eq, Ord, Read)
+
+instance Show DagDataEncoding where
+  show DagJSON = "dag-json"
+  show DagPB   = "dag-pb"
+  show DagCBOR = "dag-cbor"
+
+instance ToHttpApiData DagDataEncoding where
+  toQueryParam = Text.pack . show
+
+data CIDResponse = CIDResponse
+  { cid :: Multihash
+  } deriving (Eq, Show)
+
+instance FromJSON CIDResponse where
+  parseJSON = withObject "CIDResponse" $ \o -> do
+    cidObject <- o .: "Cid"
+    CIDResponse <$> cidObject .: "/"

--- a/src/Network/IPFS/API/V0/Types.hs
+++ b/src/Network/IPFS/API/V0/Types.hs
@@ -4,6 +4,7 @@ import           Control.Applicative                   ((<|>))
 import           Data.Aeson
 import           Data.ByteString.Lazy                  (ByteString)
 import qualified Data.HashMap.Strict                   as HM
+import qualified Data.IPLD.CID                         as IPLD
 import qualified Data.Map.Strict                       as M
 import           Data.Semigroup                        (Semigroup (..))
 import qualified Data.Text                             as Text
@@ -192,10 +193,12 @@ instance ToHttpApiData DagDataEncoding where
   toQueryParam = Text.pack . show
 
 data CIDResponse = CIDResponse
-  { cid :: Multihash
+  { cid :: IPLD.CID
   } deriving (Eq, Show)
 
 instance FromJSON CIDResponse where
   parseJSON = withObject "CIDResponse" $ \o -> do
     cidObject <- o .: "Cid"
-    CIDResponse <$> cidObject .: "/"
+    IPLD.cidFromText <$> cidObject .: "/" >>= \case
+      Left err -> fail err
+      Right cid -> return $ CIDResponse cid

--- a/src/Network/IPFS/API/V0/V0.hs
+++ b/src/Network/IPFS/API/V0/V0.hs
@@ -12,12 +12,12 @@ type RootApi = GetNodeID :<|> CatObject :<|> PostAddObjects
 -- GET /api/v0/id
 type GetNodeID =
   "id" :> IPFSArgOpt "ID of node to get info for" String
-       :> Get '[JSON] IPFSNodeInfo
+       :> Post '[JSON] IPFSNodeInfo
 
--- GET /api/v0/object
+-- POST /api/v0/cat
 type CatObject =
   "cat" :> IPFSArg "ipfs path of object" IPFSPath
-        :> Get '[PlainTextBinary] ByteString
+        :> Post '[PlainTextBinary] ByteString
 
 -- POST /api/v0/add
 type PostAddObjects =

--- a/src/Network/IPFS/Client.hs
+++ b/src/Network/IPFS/Client.hs
@@ -11,7 +11,7 @@ v0GetNode        :: Maybe String -> ClientM IPFSNodeInfo
 v0CatObject      :: Multihash -> ClientM ByteString
 v0PostAddObjects :: [AddFile] -> ClientM [AddObjectResponse]
 v0BlockGet       :: Multihash -> ClientM ByteString
-v0BlockPut       :: BlockPutData -> ClientM BlockStatResponse
+v0BlockPut       :: PutData -> ClientM BlockStatResponse
 v0BlockStat      :: Multihash -> ClientM BlockStatResponse
 v0BlockRm        :: Multihash -> ClientM BlockRmResponse
 v0PinAdd         :: String -> Bool -> Bool -> ClientM PinModResponse
@@ -19,7 +19,11 @@ v0PinLs          :: Maybe [Char] -> Maybe PinListType -> ClientM PinLsResponse
 v0PinRm          :: String -> Bool -> ClientM PinModResponse
 v0PinUpdate      :: String -> String -> Bool -> ClientM String
 v0PinVerify      :: ClientM ()
+v0DagGet         :: Multihash -> Maybe DagDataEncoding -> ClientM ByteString
+v0DagPut         :: Maybe DagDataEncoding -> [AddFile] -> ClientM CIDResponse
 
 (v0GetNode :<|> v0CatObject :<|> v0PostAddObjects)
   :<|> (v0BlockGet :<|> v0BlockPut :<|> v0BlockStat :<|> v0BlockRm)
-  :<|> (v0PinAdd :<|> v0PinLs :<|> v0PinRm :<|> v0PinUpdate :<|> v0PinVerify) = client apiV0
+  :<|> (v0PinAdd :<|> v0PinLs :<|> v0PinRm :<|> v0PinUpdate :<|> v0PinVerify) 
+  :<|> (v0DagGet :<|> v0DagPut)
+  = client apiV0

--- a/src/Servant/MultipartFormData.hs
+++ b/src/Servant/MultipartFormData.hs
@@ -17,7 +17,7 @@ import           Network.HTTP.Media.MediaType
 import           Servant.API
 import           Servant.Client
 import           Servant.Client.Core                   hiding (RequestBody (..))
-import qualified Servant.Client.Core                   as Servant 
+import qualified Servant.Client.Core                   as Servant
 
 -- | A type that can be converted to a multipart/form-data value.
 class ToMultipartFormData a where
@@ -30,6 +30,7 @@ data MultipartFormDataReqBody a
 instance (MonadIO m, RunClient m, MimeUnrender ct a, ToMultipartFormData b) =>
   HasClient m (MultipartFormDataReqBody b :> Post (ct ': cts) a) where
     type Client m (MultipartFormDataReqBody b :> Post (ct ': cts) a) = b -> m a
+    hoistClientMonad pm _ f cl = hoistClientMonad pm (Proxy :: Proxy (Post (ct ': cts) a)) f . cl
     clientWithRoute pm _ req mpdata = do
       boundary <- liftIO webkitBoundary
       reqBody <- liftIO $ renderParts boundary (toMultipartFormData mpdata)

--- a/stack.yaml
+++ b/stack.yaml
@@ -15,7 +15,7 @@
 # resolver:
 #  name: custom-snapshot
 #  location: "./custom-snapshot.yaml"
-resolver: lts-12.14
+resolver: lts-18.28
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.
@@ -40,11 +40,12 @@ packages:
 # Dependency packages to be pulled from upstream that are not in the resolver
 # (e.g., acme-missiles-0.3)
 extra-deps:
-- aeson-1.2.4.0
-- servant-0.13.0.1
-- servant-client-0.13.0.1
-- servant-client-core-0.13.0.1
-- base-compat-0.9.3
+- base32-z-bytestring-1.0.0.0
+- binary-varint-0.1.0.0
+- ipld-cid-0.1.0.0
+- multibase-0.1.2
+- multihash-cryptonite-0.1.0.0
+- sandi-0.5
 
 # Override default flag values for local packages and extra-deps
 # flags: {}

--- a/test/Utils.hs
+++ b/test/Utils.hs
@@ -16,7 +16,7 @@ globalEnv :: ClientEnv
 globalEnv = unsafePerformIO $ do
   manager <- newManager defaultManagerSettings
   let baseUrl = BaseUrl Http "localhost" 5001 ""
-  return $ ClientEnv manager baseUrl Nothing
+  return $ mkClientEnv manager baseUrl
 {-# NOINLINE globalEnv #-}
 
 withClient :: SpecWith ClientEnv -> Spec
@@ -25,6 +25,9 @@ withClient spec = before (return globalEnv) spec
 -- the multihash of test/fixtures/testfile.txt as added via `ipfs add`
 testfileTxtHash :: String
 testfileTxtHash = "Qma4hjFTnCasJ8PVp3mZbZK5g2vGDT4LByLJ7m8ciyRFZP"
+
+testJSONHash :: String
+testJSONHash = "zdpuAyBZjeKaoAZkKGyNH82CP1QUhVvLHATdFTZcbpv84Tgwm"
 
 -- the exact contents of that file
 testfileTxtContents :: BL.ByteString

--- a/test/Utils.hs
+++ b/test/Utils.hs
@@ -26,7 +26,13 @@ withClient spec = before (return globalEnv) spec
 testfileTxtHash :: String
 testfileTxtHash = "Qma4hjFTnCasJ8PVp3mZbZK5g2vGDT4LByLJ7m8ciyRFZP"
 
+testJSONHash :: String
+testJSONHash = "bafyreif5tiacshzdgycildbxumfz7bp4vbtljdiybhnrf2i2xxumixrmiq"
+
 -- the exact contents of that file
 testfileTxtContents :: BL.ByteString
 testfileTxtContents = unsafePerformIO $ BL.readFile "test/fixtures/testfile"
+
+testJSONFileContents :: BL.ByteString
+testJSONFileContents = unsafePerformIO $ BL.readFile "test/fixtures/test.json"
 {-# NOINLINE testfileTxtContents #-}

--- a/test/Utils.hs
+++ b/test/Utils.hs
@@ -26,9 +26,6 @@ withClient spec = before (return globalEnv) spec
 testfileTxtHash :: String
 testfileTxtHash = "Qma4hjFTnCasJ8PVp3mZbZK5g2vGDT4LByLJ7m8ciyRFZP"
 
-testJSONHash :: String
-testJSONHash = "bafyreif5tiacshzdgycildbxumfz7bp4vbtljdiybhnrf2i2xxumixrmiq"
-
 -- the exact contents of that file
 testfileTxtContents :: BL.ByteString
 testfileTxtContents = unsafePerformIO $ BL.readFile "test/fixtures/testfile"

--- a/test/V0/DagAPISpec.hs
+++ b/test/V0/DagAPISpec.hs
@@ -8,10 +8,7 @@ import           Utils
 
 spec :: Spec
 spec = describe "the v0 Dag API" . withClient $ do
-  it "can put dags" $ \c -> do
-    res <- try c $ v0DagPut (Just DagJSON) [AddFile "test.json" testJSONFileContents]
-    res `shouldBe` CIDResponse testJSONHash
-
-  it "can get dags" $ \c -> do
-    res <- try c $ v0DagGet testJSONHash (Just DagJSON)
-    res `shouldBe` testJSONFileContents
+  it "can put and get" $ \c -> do
+    (CIDResponse cid) <- try c $ v0DagPut (Just DagJSON) [AddFile "test.json" testJSONFileContents]
+    getRes <- try c $ v0DagGet cid (Just DagJSON)
+    getRes `shouldBe` testJSONFileContents

--- a/test/V0/DagAPISpec.hs
+++ b/test/V0/DagAPISpec.hs
@@ -1,0 +1,17 @@
+module V0.DagAPISpec where
+
+import           Network.IPFS.API.V0.Types
+import           Network.IPFS.Client
+import           Test.Hspec
+import           Test.Hspec.Expectations
+import           Utils
+
+spec :: Spec
+spec = describe "the v0 Dag API" . withClient $ do
+  it "can put dags" $ \c -> do
+    res <- try c $ v0DagPut (Just DagJSON) [AddFile "test.json" testJSONFileContents]
+    res `shouldBe` CIDResponse testJSONHash
+
+  it "can get dags" $ \c -> do
+    res <- try c $ v0DagGet testJSONHash (Just DagJSON)
+    res `shouldBe` testJSONFileContents

--- a/test/V0/DagAPISpec.hs
+++ b/test/V0/DagAPISpec.hs
@@ -1,5 +1,7 @@
 module V0.DagAPISpec where
 
+import qualified Data.IPLD.CID             as IPLD
+import           Data.String.Conversions   (cs)
 import           Network.IPFS.API.V0.Types
 import           Network.IPFS.Client
 import           Test.Hspec
@@ -8,7 +10,12 @@ import           Utils
 
 spec :: Spec
 spec = describe "the v0 Dag API" . withClient $ do
-  it "can put and get" $ \c -> do
+
+  it "can put dags" $ \c -> do
     (CIDResponse cid) <- try c $ v0DagPut (Just DagJSON) [AddFile "test.json" testJSONFileContents]
-    getRes <- try c $ v0DagGet cid (Just DagJSON)
+    let cidString = cs . IPLD.cidToText $ cid
+    cidString `shouldBe` testJSONHash
+
+  it "can get dags" $ \c -> do
+    getRes <- try c $ v0DagGet testJSONHash (Just DagJSON)
     getRes `shouldBe` testJSONFileContents

--- a/test/fixtures/test.json
+++ b/test/fixtures/test.json
@@ -1,0 +1,1 @@
+{"msg":"Hello World!"}


### PR DESCRIPTION
API still works, except most endpoints are now `POST`s instead of `GET`s.

Also adds `dag` endpoints for `get` and `put`.